### PR TITLE
Add location filtering

### DIFF
--- a/DowneSpace/test.py
+++ b/DowneSpace/test.py
@@ -31,8 +31,9 @@ class TestCase(BaseTestCase):
     user.save()
     return user
 
-  def create_event(self, name='', description=''):
-    with patch('core.receivers.get_coords'):
+  def create_event(self, name='', description='', lat=None, lon=None):
+    with patch('core.receivers.get_coords') as get_coords:
+      get_coords.return_value = {'lat': lat or 1.0, 'lng': lon or 1.0}
       return Event.objects.create(
         name        = name,
         description = description,

--- a/appfiles/app/index.html
+++ b/appfiles/app/index.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="styles/main.css">
     <!-- endbuild -->
   </head>
-  <body ng-app="downespace">
+  <body>
     <!--[if lte IE 8]>
       <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
     <![endif]-->
@@ -56,6 +56,8 @@
     <script src="bower_components/moment/moment.js"></script>
     <script src="bower_components/moment-timezone/builds/moment-timezone-with-data-2010-2020.js"></script>
     <script src="bower_components/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js"></script>
+    <script src="bower_components/angular-ui-utils/ui-utils.js"></script>
+    <script src="bower_components/angular-ui-map/ui-map.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 
@@ -70,9 +72,18 @@
     <script src="scripts/directives/footer.js"></script>
     <script src="scripts/directives/input.js"></script>
     <script src="scripts/directives/topbar.js"></script>
+    <script src="scripts/services/address.js"></script>
     <script src="scripts/services/auth.js"></script>
     <script src="scripts/services/date.js"></script>
     <script src="scripts/services/event.js"></script>
     <!-- endbuild -->
+    <script>
+    function onGoogleReady() {
+      angular.bootstrap(document, ['downespace']);
+    }
+    </script>
+    <script type="text/javascript"
+      src="https://maps.googleapis.com/maps/api/js?v=3.exp&callback=onGoogleReady">
+    </script>
 </body>
 </html>

--- a/appfiles/app/scripts/app.coffee
+++ b/appfiles/app/scripts/app.coffee
@@ -15,7 +15,8 @@ angular
     'ngResource',
     'ngRoute',
     'ngSanitize',
-    'ngTouch'
+    'ngTouch',
+    'ui.map'
   ]
   .run ($rootScope, Auth) ->
     Auth.getUser().then (data) ->

--- a/appfiles/app/scripts/directives/eventlist.coffee
+++ b/appfiles/app/scripts/directives/eventlist.coffee
@@ -10,20 +10,21 @@ angular.module('downespace').directive 'eventList', ->
 
 angular.module('downespace').controller 'eventListController', (Event) ->
 
-  this.events   = []
-  this.nextPage = 1
-  this.more     = true
-  this.gridView = true
+  this.resetEvents = =>
+    this.events   = []
+    this.nextPage = 1
+    this.more     = true
+    this.gridView = true
+    this.filters = {}
+    return
 
   this.getEvents = =>
-    Event.getEvents(this.nextPage).then (eventData) =>
+    Event.getEvents(this.nextPage, this.filters).then (eventData) =>
       this.events.push eventData.events...
       this.more = eventData.more
       if this.more
         this.nextPage = eventData.page + 1
       return
     return
-
-  this.getEvents()
 
   return

--- a/appfiles/app/scripts/directives/filterevents.coffee
+++ b/appfiles/app/scripts/directives/filterevents.coffee
@@ -17,7 +17,6 @@ angular.module('downespace').controller 'filterEventsController',
     this.eventList       = $scope.eventList
     this.filters         = {}
     this.expanded        = false
-    this.waiting         = false
     # debounce 500ms unless blur (lose focus), then update immediately
     this.locationOptions = updateOn: 'default blur', debounce: {default: 500, blur: 0}
 
@@ -76,7 +75,6 @@ angular.module('downespace').controller 'filterEventsController',
     $scope.$watch (=> this.location), (location) =>
       if location
         this.coordPromise = Address.getCoords(location).then (results) =>
-          this.waiting          = false
           result                = results[0]
           this.formattedAddress = result.formatted_address
           this.filters.lat      = result.geometry.location.lat()

--- a/appfiles/app/scripts/directives/filterevents.coffee
+++ b/appfiles/app/scripts/directives/filterevents.coffee
@@ -4,16 +4,97 @@ angular.module('downespace').directive 'filterEvents', ->
   directive =
     controller  : 'filterEventsController'
     controllerAs: 'filterEvents'
+    require     : '^eventList'
     restrict    : 'E'
     templateUrl : 'views/directives/filterevents.html'
+    link        : (scope, element, attrs, eventList) ->
+      scope.eventList = eventList
+      return
   return directive
 
-angular.module('downespace').controller 'filterEventsController', (Event) ->
+angular.module('downespace').controller 'filterEventsController',
+  ($location, $scope, Event, Address) ->
+    this.eventList       = $scope.eventList
+    this.filters         = {}
+    this.expanded        = false
+    this.waiting         = false
+    # debounce 500ms unless blur (lose focus), then update immediately
+    this.locationOptions = updateOn: 'default blur', debounce: {default: 500, blur: 0}
 
-  this.expanded = false
+    this.toggle = =>
+      this.expanded = not this.expanded
+      return
 
-  this.toggle = =>
-    this.expanded = not this.expanded
+    this.parseParams = =>
+      validParams = ['location', 'range']
+      params = $location.search()
+
+      for key, value of params
+        if key not in validParams
+          continue
+
+        # show filter bar by default if search is being populated by url params
+        if not this.expended
+          this.expanded = true
+
+        # location requires extra logic (external api call), so handle special
+        if key is 'location'
+          this.location = value
+        else
+          this.filters[key] = value
+      return
+
+    this.setParams = =>
+      if this.location
+        $location.search 'location', this.location
+      if this.filters.range
+        $location.search 'range', this.filters.range
+      return
+
+    this.submitNewFilters = =>
+      submit = =>
+        this.eventList.resetEvents()
+        this.setParams()
+        this.eventList.filters = this.filters
+        this.eventList.getEvents()
+        return
+
+      watch = $scope.$watch (=> this.coordPromise), (promise) ->
+        # if coordPromise has 'then' function, wait for promise to resolve
+        if typeof promise?.then is 'function'
+          promise.then ->
+            submit()
+            return
+        # otherwise, no promise waiting for coords is present
+        else
+          submit()
+        # deregister watch as we only want this to run once per call
+        watch()
+        return
+      return
+
+    $scope.$watch (=> this.location), (location) =>
+      if location
+        this.coordPromise = Address.getCoords(location).then (results) =>
+          this.waiting          = false
+          result                = results[0]
+          this.formattedAddress = result.formatted_address
+          this.filters.lat      = result.geometry.location.lat()
+          this.filters.lon      = result.geometry.location.lng()
+          return
+      else
+        delete this.formattedAddress
+        delete this.filters.lat
+        delete this.filters.lon
+      return
+
+    $scope.$watch (=> this.filters), (filters) ->
+      for key, value of filters
+        if not value
+          delete filters[key]
+      return
+    , true
+
+    this.parseParams()
+    this.submitNewFilters()
     return
-
-  return

--- a/appfiles/app/scripts/services/address.coffee
+++ b/appfiles/app/scripts/services/address.coffee
@@ -1,0 +1,13 @@
+'use strict'
+
+angular.module('downespace').service 'Address', ($q) ->
+  geocoder = new google.maps.Geocoder()
+
+  this.getCoords = (address) ->
+    deferred = $q.defer()
+    geocoder.geocode 'address': address, (results, status) ->
+      deferred.resolve results
+      return
+    return deferred.promise
+
+  return

--- a/appfiles/app/scripts/services/event.coffee
+++ b/appfiles/app/scripts/services/event.coffee
@@ -22,8 +22,7 @@ angular.module('downespace').service 'Event', ($http, Date) ->
     return $http.post('/api/event/', newEvent).then ({data}) -> data
 
   service.getEvents = (page=1, filters) ->
-    params = page: page
-    params = _.merge params, filters
+    params = _.merge page: page, filters
     return $http.get('/api/events/', params: params).then ({data}) ->
       data.events = service.processEvents data.events
       return data

--- a/appfiles/app/scripts/services/event.coffee
+++ b/appfiles/app/scripts/services/event.coffee
@@ -21,8 +21,9 @@ angular.module('downespace').service 'Event', ($http, Date) ->
       newEvent.end = Date.toTimestamp newEvent.end
     return $http.post('/api/event/', newEvent).then ({data}) -> data
 
-  service.getEvents = (page=1) ->
+  service.getEvents = (page=1, filters) ->
     params = page: page
+    params = _.merge params, filters
     return $http.get('/api/events/', params: params).then ({data}) ->
       data.events = service.processEvents data.events
       return data

--- a/appfiles/app/styles/views/filterevents.less
+++ b/appfiles/app/styles/views/filterevents.less
@@ -14,7 +14,6 @@
 
 .filter-expanded {
   margin-bottom: 20px;
-  transition: margin-top 400ms ease, visibility 0s ease 0s;
 
   .row {
     margin-bottom: 10px;

--- a/appfiles/app/views/directives/eventlist.html
+++ b/appfiles/app/views/directives/eventlist.html
@@ -1,3 +1,4 @@
+<filter-events></filter-events>
 <div class="container col-xs-12" style="margin-bottom: 20px;">
   <div class="well well-sm">
     <div class="btn-group">

--- a/appfiles/app/views/directives/filterevents.html
+++ b/appfiles/app/views/directives/filterevents.html
@@ -10,7 +10,19 @@
   </div>
   <div class="row">
     <div class="col-xs-4">Distance</div>
-    <div class="col-xs-8">slider bar</div>
+    <div class="col-xs-8">
+        <input
+          type="text"
+          ng-model="filterEvents.location"
+          ng-model-options="filterEvents.locationOptions"
+          placeholder="Address, City, or Zip">
+        <input
+          type="text"
+          ng-model="filterEvents.filters.range"
+          ng-model-options="filterEvents.locationOptions"
+          placeholder="Range in miles">
+        {{ filterEvents.formattedAddress }}
+    </div>
   </div>
   <div class="row">
     <div class="col-xs-4">Date</div>
@@ -20,4 +32,10 @@
     <div class="col-xs-4">Tags</div>
     <div class="col-xs-8">bubbles</div>
   </div>
+  <button
+    type="submit"
+    class="btn btn-default"
+    ng-click="filterEvents.submitNewFilters()">
+    Submit Filters
+  </button>
 </div>

--- a/appfiles/app/views/main.html
+++ b/appfiles/app/views/main.html
@@ -15,5 +15,4 @@
   </div>
 </div>
 
-<filter-events></filter-events>
 <event-list></event-list>

--- a/appfiles/bower.json
+++ b/appfiles/bower.json
@@ -12,7 +12,8 @@
     "angular-touch": "^1.3.0",
     "lodash": "~3.10.1",
     "moment": "~2.10.6",
-    "eonasdan-bootstrap-datetimepicker": "~4.17.37"
+    "eonasdan-bootstrap-datetimepicker": "~4.17.37",
+    "angular-ui-map": "~0.5.0"
   },
   "devDependencies": {
     "angular-mocks": "^1.3.0"

--- a/appfiles/test/karma.conf.coffee
+++ b/appfiles/test/karma.conf.coffee
@@ -30,6 +30,8 @@ module.exports = (config) ->
       'bower_components/moment/moment.js'
       'bower_components/moment-timezone/builds/moment-timezone-with-data-2010-2020.js'
       'bower_components/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js'
+      'bower_components/angular-ui-utils/ui-utils.js'
+      'bower_components/angular-ui-map/ui-map.js'
       'bower_components/angular-mocks/angular-mocks.js'
       # endbower
       # bower:coffee

--- a/appfiles/test/spec/directives/eventlist.coffee
+++ b/appfiles/test/spec/directives/eventlist.coffee
@@ -11,15 +11,7 @@ describe 'Directive: eventList', ->
       this.$httpBackend = $httpBackend
       this.Event        = Event
       this.$q           = $q
-
-    this.createController = =>
-      this.controller = this.$controller 'eventListController',
-        $rootScope: this.$rootScope
-      , this.$rootScope
-      this.$rootScope.$digest()
       return
-
-    this.$httpBackend.expectGET("/api/auth/").respond {}
 
     this.timestamp = 1420095600
 
@@ -47,22 +39,39 @@ describe 'Directive: eventList', ->
       more       : true
     }
 
+    this.$httpBackend.expectGET('/api/auth/').respond {}
+    this.controller = this.$controller 'eventListController'
+    this.controller.resetEvents()
+    this.$rootScope.$digest()
+    this.$httpBackend.flush()
+    return
 
   afterEach ->
     this.$httpBackend.verifyNoOutstandingExpectation()
     this.$httpBackend.verifyNoOutstandingRequest()
+    return
 
-  it 'should get events on start', ->
-    this.$httpBackend.expectGET("/api/events/?page=1").respond this.expectedResponse
-    this.createController()
+  it 'should reset event data', ->
+    expect(this.controller.events).toEqual []
+    expect(this.controller.nextPage).toEqual 1
+    expect(this.controller.more).toEqual true
+    expect(this.controller.gridView).toEqual true
+    expect(this.controller.filters).toEqual {}
+    return
+
+  it 'should get events', ->
+    this.$httpBackend.expectGET('/api/events/?page=1').respond this.expectedResponse
+    this.controller.getEvents()
     this.$httpBackend.flush()
     expect(this.controller.events).toEqual this.Event.processEvents(this.events)
+    return
 
   it 'should get more events', ->
-    this.$httpBackend.expectGET("/api/events/?page=1").respond this.expectedResponse
-    this.createController()
+    this.$httpBackend.expectGET('/api/events/?page=1').respond this.expectedResponse
+    this.controller.getEvents()
     this.$httpBackend.flush()
 
+    expect(this.controller.events).toEqual this.Event.processEvents(this.events)
     expect(this.controller.events).toEqual this.Event.processEvents(this.events)
     expect(this.controller.more).toBe true
     expect(this.controller.nextPage).toEqual 2
@@ -70,7 +79,10 @@ describe 'Directive: eventList', ->
     this.expectedResponse.more = false
 
     this.controller.getEvents()
-    this.$httpBackend.expectGET("/api/events/?page=2").respond this.expectedResponse
+    this.$httpBackend.expectGET('/api/events/?page=2').respond this.expectedResponse
     this.$httpBackend.flush()
 
     expect(this.controller.more).toBe false
+    return
+
+  return

--- a/appfiles/test/spec/directives/filterevents.coffee
+++ b/appfiles/test/spec/directives/filterevents.coffee
@@ -1,0 +1,121 @@
+'use strict'
+
+describe 'Directive: filterEvents', ->
+
+  beforeEach ->
+    module 'downespace'
+
+    inject ($controller, $httpBackend, $location, $q, $rootScope, Event) ->
+      this.$controller  = $controller
+      this.$httpBackend = $httpBackend
+      this.$location    = $location
+      this.$q           = $q
+      this.$scope       = $rootScope.$new()
+      this.Event        = Event
+      return
+
+    mockAddrData = [
+      {
+        formatted_address: '123 some street'
+        geometry:
+          location:
+            lat: -> 1
+            lng: -> 1
+      }
+    ]
+
+    this.Address =
+      getCoords: jasmine.createSpy('getCoords').and.returnValue this.$q.when mockAddrData
+    this.eventList =
+      getEvents  : jasmine.createSpy 'getEvents'
+      resetEvents: jasmine.createSpy 'resetEvents'
+
+    this.controller = this.$controller 'filterEventsController',
+      $location: this.$location
+      $scope   : this.$scope
+      Event    : this.Event
+      Address  : this.Address
+
+    this.controller.eventList = this.eventList
+
+    return
+
+  it 'should toggle expanded', ->
+    this.controller.toggle()
+    expect(this.controller.expanded).toBe true
+
+    this.controller.toggle()
+    expect(this.controller.expanded).toBe false
+    return
+
+  it 'should parse url query params', ->
+    this.controller.parseParams()
+    expect(this.controller.expanded).toBe false
+
+    spyOn(this.$location, 'search').and.returnValue range: 10, location: 94062, foo: 'bar'
+    this.controller.parseParams()
+
+    expect(this.controller.location).toEqual 94062
+    expect(this.controller.filters.range).toEqual 10
+    expect(this.controller.expanded).toBe true
+    return
+
+  it 'should set url query params', ->
+    this.controller.location = 94062
+    this.controller.filters.range = 10
+    this.controller.setParams()
+
+    expect(this.$location.search()).toEqual location: 94062, range: 10
+    return
+
+  it 'should submit filter changes on load - no filters', ->
+    this.$httpBackend.expectGET('/api/auth/').respond {}
+    spyOn(this.controller, 'setParams').and.callThrough()
+    this.$scope.$digest()
+
+    expect(this.Address.getCoords).not.toHaveBeenCalled()
+    expect(this.controller.eventList.resetEvents).toHaveBeenCalledWith()
+    expect(this.controller.setParams).toHaveBeenCalledWith()
+    expect(this.controller.eventList.filters).toEqual {}
+    expect(this.controller.eventList.getEvents).toHaveBeenCalledWith()
+    return
+
+  it 'should submit filter changes on load', ->
+    this.$httpBackend.expectGET('/api/auth/').respond {}
+    spyOn(this.controller, 'setParams').and.callThrough()
+    this.controller.location = 94062
+    this.$scope.$digest()
+
+    expect(this.Address.getCoords).toHaveBeenCalledWith(94062)
+    expect(this.controller.eventList.resetEvents).toHaveBeenCalledWith()
+    expect(this.controller.setParams).toHaveBeenCalledWith()
+    expect(this.controller.eventList.filters).toEqual lat: 1, lon: 1
+    expect(this.controller.eventList.getEvents).toHaveBeenCalledWith()
+    return
+
+  it 'should update address on location change', ->
+    this.$httpBackend.expectGET('/api/auth/').respond {}
+    this.controller.location = 94062
+    this.$scope.$digest()
+
+    expect(this.controller.formattedAddress).toEqual '123 some street'
+    expect(this.controller.filters.lat).toEqual 1
+    expect(this.controller.filters.lon).toEqual 1
+
+    this.controller.location = undefined
+    this.$scope.$digest()
+
+    expect(this.controller.formattedAddress).toBeUndefined()
+    expect(this.controller.filters.lat).toBeUndefined()
+    expect(this.controller.filters.lon).toBeUndefined()
+    return
+
+  it 'should delete empty filters', ->
+    this.$httpBackend.expectGET('/api/auth/').respond {}
+    this.controller.filters = range: undefined
+    this.$scope.$digest()
+
+    expect(this.controller.filters).toEqual {}
+    return
+
+  return

--- a/core/tests/views/test_events.py
+++ b/core/tests/views/test_events.py
@@ -10,7 +10,7 @@ class EventsViewTest(TestCase):
     self.assertResponseEqual(response, emptyResponse)
 
   def test_pagination(self):
-    for x in range(15):
+    for _ in range(15):
       self.create_event()
 
     response = self.client.get(self.url)
@@ -28,3 +28,27 @@ class EventsViewTest(TestCase):
     self.assertEqual(data['total_pages'], 2)
     self.assertEqual(len(data['events']), 6)
     self.assertEqual(data['more'], False)
+
+  def test_filter_location(self):
+    # coords for 1149 22nd St, San Francisco, CA - 22nd St Caltrain station
+    lat = 37.757528
+    lon = -122.392687
+
+    # coords for 700 Fourth St, San Francisco, CA - 4th and King Caltrain station
+    event1 = self.create_event(name='event1', lat=37.776665, lon=-122.394706)
+
+    # coords for 95 University Ave, Palo Alto, CA - Palo Alto Caltrain station
+    self.create_event(name='event2', lat=37.443425, lon=-122.165174)
+
+    # 10 mile range
+    response = self.client.get(self.url, {'lat': lat, 'lon': lon, 'range': 10})
+    data = self.getJsonResponse(response)
+
+    self.assertEqual(len(data['events']), 1)
+    self.assertEqual(data['events'][0]['name'], event1.name)
+
+    # 30 mile range
+    response = self.client.get(self.url, {'lat': lat, 'lon': lon, 'range': 30})
+    data = self.getJsonResponse(response)
+
+    self.assertEqual(len(data['events']), 2)

--- a/core/views/events.py
+++ b/core/views/events.py
@@ -2,16 +2,26 @@ from django.core.paginator import EmptyPage, Paginator
 from django.http import JsonResponse
 from rest_framework.views import APIView
 
-from ..models import Event
+from ..location_utils import mi_to_km
+from ..models import Coords, Event
 from ..serializers import EventSerializer
 
 
 class EventsView(APIView):
 
   def get(self, request, *args, **kwargs):
-    all_events = Event.objects.all()
+    events = Event.objects.all()
+
+    # location range filter
+    lat, lon, loc_range = [request.GET.get(key) for key in ['lat', 'lon', 'range']]
+    if lat and lon and loc_range:
+      # coord filter expects kilometers
+      loc_range = mi_to_km(float(loc_range))
+      coord_ids = Coords.objects.nearby(lat, lon, loc_range).values_list('id', flat=True)
+      events    = events.filter(coords__in=coord_ids)
+
     # 9 events per page
-    paginator = Paginator(all_events, 9)
+    paginator = Paginator(events, 9)
 
     page = int(request.GET.get('page', 1))
     try:


### PR DESCRIPTION
This allows for filtering of events based
on location (in this case, lat/long coords).
Lat/long was chosen because address would require
an extra API call that will eventually need
to be done on the frontend anyway.

TODO:
- [ ] decouple logic between eventlist and filterevents directives in a sensible way
- [ ] track if filters have been changed to properly reset pagination call
- [x] frontend url params for filters
- [x] frontend unit tests